### PR TITLE
Fix broken match feature in engine.sh

### DIFF
--- a/modules/acl/engine.sh
+++ b/modules/acl/engine.sh
@@ -635,12 +635,19 @@ path_intersects_any_filter() {
 
 # Pattern matching utilities
 match_glob() {
-    # Usage for internal engine: match_glob TEXT PATTERN CASE_SENSITIVE
-    # Tests may call with extra args (match_base and multiple patterns). Support both forms.
+    # Usage for internal engine: match_glob TEXT PATTERN CASE_SENSITIVE [MATCH_BASE] [PATTERN...]
+    # Supports being called with either 3 args (no match_base, no extra patterns)
+    # or 4+ args (explicit match_base followed by optional additional patterns).
     local text="$1" pattern="$2" case_sensitive="${3:-true}"
-    local match_base="${4:-false}"
-    shift 4 || true
-    local additional_patterns=("$@")
+    local match_base="false"
+    local additional_patterns=()
+    if [[ $# -ge 4 ]]; then
+        match_base="$4"
+        shift 4
+        additional_patterns=("$@")
+    else
+        shift 3
+    fi
 
     _glob_match_one() {
         local t="$1" p="$2" cs="$3"


### PR DESCRIPTION
Fix `match_glob` argument parsing in `engine.sh` to correctly apply include filters.

The `match_glob` function was incorrectly parsing its optional arguments, leading to include filters (e.g., `include: ["*.doesnotexist"]`) always matching, effectively bypassing the intended filtering logic. This change corrects the argument handling to properly distinguish between the different call signatures, ensuring filters are applied as expected.

---
<a href="https://cursor.com/background-agent?bcId=bc-9dd2ddbe-12a0-4935-bb48-0a08df08b7a5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9dd2ddbe-12a0-4935-bb48-0a08df08b7a5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>