### PR TITLE
Fix cache retrieval edge cases in engine.sh

### DIFF
--- a/modules/acl/engine.sh
+++ b/modules/acl/engine.sh
@@ -160,25 +160,69 @@ declare -A cache_types=()
 # Cache service interface
 cache_get() {
     local -r cache_type="$1" key="$2"
-    local -n cache_ref="cache_${cache_type}"
-    if [[ -n "${cache_ref[$key]:-}" ]]; then
-        RUNTIME_STATE[cache_hits]=$((${RUNTIME_STATE[cache_hits]} + 1))
-        echo "${cache_ref[$key]}"
-        return 0
-    fi
+    case "$cache_type" in
+        rules)
+            if [[ ${cache_rules[$key]+_} ]]; then
+                RUNTIME_STATE[cache_hits]=$((${RUNTIME_STATE[cache_hits]} + 1))
+                printf '%s\n' "${cache_rules[$key]}"
+                return 0
+            fi
+            ;;
+        groups)
+            if [[ ${cache_groups[$key]+_} ]]; then
+                RUNTIME_STATE[cache_hits]=$((${RUNTIME_STATE[cache_hits]} + 1))
+                printf '%s\n' "${cache_groups[$key]}"
+                return 0
+            fi
+            ;;
+        types)
+            if [[ ${cache_types[$key]+_} ]]; then
+                RUNTIME_STATE[cache_hits]=$((${RUNTIME_STATE[cache_hits]} + 1))
+                printf '%s\n' "${cache_types[$key]}"
+                return 0
+            fi
+            ;;
+        *)
+            return 1
+            ;;
+    esac
     return 1
 }
 
 cache_set() {
     local -r cache_type="$1" key="$2" value="$3"
-    local -n cache_ref="cache_${cache_type}"
-    cache_ref[$key]="$value"
+    case "$cache_type" in
+        rules)
+            cache_rules[$key]="$value"
+            ;;
+        groups)
+            cache_groups[$key]="$value"
+            ;;
+        types)
+            cache_types[$key]="$value"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
 }
 
 cache_clear() {
     local -r cache_type="$1"
-    local -n cache_ref="cache_${cache_type}"
-    cache_ref=()
+    case "$cache_type" in
+        rules)
+            cache_rules=()
+            ;;
+        groups)
+            cache_groups=()
+            ;;
+        types)
+            cache_types=()
+            ;;
+        *)
+            return 1
+            ;;
+    esac
 }
 
 # Efficient rule data caching - consolidates all jq calls into one pass
@@ -218,7 +262,12 @@ cache_all_rules() {
 
     # Parse and cache the structured data
     local rules_count="0" apply_order="shallow_to_deep"
-    while IFS='|' read -r -a parts; do
+    local sentinel='__CACHE_SENTINEL__'
+    local line
+    while IFS= read -r line; do
+        local -a parts=()
+        IFS='|' read -r -a parts <<< "${line}|${sentinel}"
+        unset "parts[${#parts[@]}-1]"
         [[ ${#parts[@]} -gt 0 ]] || continue
         case "${parts[0]}" in
             apply_order) apply_order="${parts[1]}" ;;
@@ -505,8 +554,11 @@ validate_groups() {
     # Skip if getent not available
     command -v getent >/dev/null 2>&1 || return 0
 
-    local rules_count
-    rules_count=$(cache_get rules "rules_count")
+    local rules_count="0"
+    if ! rules_count=$(cache_get rules "rules_count" 2>/dev/null); then
+        # Without cached metadata there is nothing to validate
+        return 0
+    fi
 
     local -A groups_to_check=()
     for ((i=0; i<rules_count; i++)); do
@@ -1244,6 +1296,11 @@ execute_rule() {
 
     local rule_failed=0
 
+    local apply_order_cached
+    if ! apply_order_cached=$(cache_get rules "apply_order" 2>/dev/null); then
+        apply_order_cached="shallow_to_deep"
+    fi
+
     # Apply strategy to roots
     for root in "${valid_roots[@]}"; do
         local root_failed=0
@@ -1267,7 +1324,7 @@ execute_rule() {
                 mapfile -t paths < <(enumerate_paths_simple "$include_root" "$depth" "$root")
                 # Order paths by apply_order for deterministic override behavior
                 local -a ordered_paths=()
-                while IFS= read -r p; do ordered_paths+=("$p"); done < <(sort_paths_by_apply_order "$(cache_get rules "apply_order")" "$root" "${paths[@]}")
+                while IFS= read -r p; do ordered_paths+=("$p"); done < <(sort_paths_by_apply_order "$apply_order_cached" "$root" "${paths[@]}")
                 local file_count=0
                 for path in "${ordered_paths[@]}"; do
                     # Ensure root is excluded when include_root is false
@@ -1327,7 +1384,7 @@ execute_rule() {
                 log_progress "Enumerating paths for individual directory processing..."
                 mapfile -t paths < <(enumerate_paths_simple "$include_root" "$depth" "$root")
                 local -a ordered_paths=()
-                while IFS= read -r p; do ordered_paths+=("$p"); done < <(sort_paths_by_apply_order "$(cache_get rules "apply_order")" "$root" "${paths[@]}")
+                while IFS= read -r p; do ordered_paths+=("$p"); done < <(sort_paths_by_apply_order "$apply_order_cached" "$root" "${paths[@]}")
                 local dir_count=0
                 for path in "${ordered_paths[@]}"; do
                     if ! path_under_any_filter "$path"; then
@@ -1374,7 +1431,7 @@ execute_rule() {
             log_progress "Enumerating paths for default ACL processing..."
             mapfile -t paths < <(enumerate_paths_simple "$include_root" "$depth" "$root")
             local -a ordered_paths=()
-            while IFS= read -r p; do ordered_paths+=("$p"); done < <(sort_paths_by_apply_order "$(cache_get rules "apply_order")" "$root" "${paths[@]}")
+            while IFS= read -r p; do ordered_paths+=("$p"); done < <(sort_paths_by_apply_order "$apply_order_cached" "$root" "${paths[@]}")
             local default_dir_count=0
             for path in "${ordered_paths[@]}"; do
                 # Ensure root is excluded when include_root is false
@@ -1626,10 +1683,14 @@ determine_target_paths() {
 
 apply_all_rules() {
     local rules_count
-    rules_count=$(cache_get rules "rules_count")
+    if ! rules_count=$(cache_get rules "rules_count" 2>/dev/null); then
+        fail "$EXIT_ERROR" "Cached rules metadata is unavailable"
+    fi
 
     local apply_order
-    apply_order=$(cache_get rules "apply_order")
+    if ! apply_order=$(cache_get rules "apply_order" 2>/dev/null); then
+        apply_order="shallow_to_deep"
+    fi
     log_info "Apply order: $apply_order"
 
     local total_rule_failures=0


### PR DESCRIPTION
## Summary
- ensure `cache_get` treats empty strings as legitimate cache hits and uses `printf` for stable output
- preserve trailing empty fields when parsing cached rule data by appending and trimming a sentinel during splitting
- replace nameref usage in cache helpers so the cache works on older bash versions
- guard cache metadata lookups so `set -euo pipefail` does not terminate on cache misses and reuse the cached apply order when sorting paths

## Testing
- `modules/acl/run_tests.sh all` *(fails: validation suite exits early while running `validate_dependencies` in the existing test harness)*

------
https://chatgpt.com/codex/tasks/task_e_68d43324ddd483268f6cadd030339eec