### PR TITLE
Fix target path validation

### DIFF
--- a/modules/acl/engine.sh
+++ b/modules/acl/engine.sh
@@ -506,7 +506,11 @@ validate_dependencies() {
 # Simple validation functions
 is_readable_file() { [[ -f "$1" && -r "$1" ]]; }
 is_valid_json()    { jq empty "$1" 2>/dev/null; }
-is_valid_path()    { [[ -n "$1" && "$1" != *$'\0'* ]]; }
+is_valid_path() {
+    [[ -n "$1" ]] || return 1
+    [[ "$1" != *$'\n'* ]] || return 1
+    return 0
+}
 is_valid_group()   { [[ "$1" =~ ^[a-zA-Z0-9_][a-zA-Z0-9_-]*$ ]]; }
 is_valid_perms()   { [[ "$1" =~ ^[rwxX-]{1,4}$ ]]; }
 is_valid_mask()    { [[ "$1" =~ ^[rwx-]{1,3}$ ]]; }

--- a/modules/acl/test_validation.sh
+++ b/modules/acl/test_validation.sh
@@ -88,7 +88,7 @@ test_is_valid_path() {
     
     # Test invalid paths
     assert_command_fails "empty path should be invalid" is_valid_path ""
-    assert_command_fails "null character should be invalid" is_valid_path $'/tmp/test\0'
+    assert_command_fails "path with newline should be invalid" is_valid_path $'multi\nline'
 }
 
 test_is_valid_group() {


### PR DESCRIPTION
## Summary
- correct the path validation helper so user-specified target directories are accepted
- adjust the validation unit test to reject paths containing newlines instead of impossible null characters

## Testing
- bash modules/acl/test_validation.sh

------
https://chatgpt.com/codex/tasks/task_e_68d551d9d5148326b53ea075cb0b2125